### PR TITLE
fix(compile): release trigger claim on success, add catch-up pass

### DIFF
--- a/template/.claude/hooks/session-start.sh
+++ b/template/.claude/hooks/session-start.sh
@@ -187,4 +187,15 @@ if [ "${#BEYIN_CONTEXT}" -gt 16000 ]; then
 fi
 
 [ -n "$BEYIN_CONTEXT" ] && beyin_emit SessionStart "$BEYIN_CONTEXT"
+
+# The evening compile is triggered from SessionEnd, which means a day whose last
+# session closes before 18:00 never reaches it and its log sits uncompiled. Fire
+# the catch-up pass here, detached and after the context is already emitted so it
+# can neither delay the session nor corrupt the hook's JSON on stdout. flush.py
+# decides whether anything is actually due; the call is cheap when it is not.
+if command -v python3 >/dev/null 2>&1; then
+  nohup python3 "$BEYIN_PROJECT_DIR/.claude/scripts/flush.py" \
+    --maybe-compile >/dev/null 2>&1 &
+fi
+
 exit 0

--- a/template/.claude/scripts/compile.py
+++ b/template/.claude/scripts/compile.py
@@ -212,6 +212,7 @@ def _daily_sort_key(path: Path) -> tuple[dt.date, str]:
 def changed_daily_logs(
     vault_root: Path,
     ingested: dict[str, str],
+    before_date: dt.date | None = None,
 ) -> list[tuple[Path, str]]:
     daily_dir = vault_root / "daily"
     if not daily_dir.exists():
@@ -229,6 +230,8 @@ def changed_daily_logs(
         file_stat = path.lstat()
         if stat.S_ISLNK(file_stat.st_mode) or not stat.S_ISREG(file_stat.st_mode):
             raise PolicyError(f"unsafe-daily-source:{path.name}")
+        if before_date is not None and _daily_sort_key(path)[0] >= before_date:
+            continue
         digest = _sha256(path)
         if ingested.get(path.name) != digest:
             changed.append((path, digest))
@@ -699,6 +702,7 @@ def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
         ),
     )
     parser.add_argument("--trigger-claim", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument("--before-date", type=dt.date.fromisoformat, help=argparse.SUPPRESS)
     return parser.parse_args(argv)
 
 
@@ -718,7 +722,11 @@ def _run_locked(args: argparse.Namespace, trigger_claim: Path | None) -> int:
         )
         return 0
     try:
-        changed = changed_daily_logs(VAULT_ROOT, state["ingested"])
+        changed = changed_daily_logs(
+            VAULT_ROOT,
+            state["ingested"],
+            before_date=args.before_date,
+        )
     except (OSError, ValueError, PolicyError) as exc:
         _record_failure(
             state_path,

--- a/template/.claude/scripts/compile.py
+++ b/template/.claude/scripts/compile.py
@@ -834,6 +834,14 @@ def main(argv: Sequence[str] | None = None) -> int:
                 trigger_claim,
             )
             return 0
+        finally:
+            # Every failure path released the claim, but the success path fell
+            # straight through without one. A compile that worked therefore left
+            # its trigger file behind, and the O_EXCL create in flush.py refused
+            # every later trigger for the rest of that day. Releasing here covers
+            # all paths; the call is idempotent, so the failure paths that
+            # already released stay correct.
+            _release_trigger_claim(trigger_claim)
 
 
 if __name__ == "__main__":

--- a/template/.claude/scripts/flush.py
+++ b/template/.claude/scripts/flush.py
@@ -473,14 +473,17 @@ def maybe_trigger_compile(
     environment = os.environ.copy()
     environment.pop("BEYIN_INVOKED_BY", None)
     launcher = popen_factory or subprocess.Popen
+    compile_argv = [
+        sys.executable,
+        str(vault_root / ".claude" / "scripts" / "compile.py"),
+        "--trigger-claim",
+        str(trigger),
+    ]
+    if not on_schedule:
+        compile_argv.extend(["--before-date", current.date().isoformat()])
     try:
         launcher(
-            [
-                sys.executable,
-                str(vault_root / ".claude" / "scripts" / "compile.py"),
-                "--trigger-claim",
-                str(trigger),
-            ],
+            compile_argv,
             cwd=vault_root,
             env=environment,
             stdout=subprocess.DEVNULL,

--- a/template/.claude/scripts/flush.py
+++ b/template/.claude/scripts/flush.py
@@ -407,10 +407,19 @@ def maybe_trigger_compile(
     vault_root: Path = VAULT_ROOT,
     now: dt.datetime | None = None,
     popen_factory: Callable[..., Any] | None = None,
+    catch_up: bool = False,
 ) -> bool:
-    """Start one detached evening compile when daily content has changed."""
+    """Start one detached compile when daily content has changed.
+
+    Two call sites, because one is not enough. SessionEnd fires the scheduled
+    evening pass at or after 18:00. SessionStart fires the catch-up pass at any
+    hour, but only for logs of days that are already over: a day whose last
+    session closes before 18:00 never reaches the evening path at all, and its
+    log would otherwise sit uncompiled indefinitely.
+    """
     current = now or _event_now()
-    if _effective_hour(current) < 18:
+    on_schedule = _effective_hour(current) >= 18
+    if not (on_schedule or catch_up):
         return False
 
     state_dir = vault_root / ".claude" / "scripts" / ".state"
@@ -433,15 +442,24 @@ def maybe_trigger_compile(
         daily_paths = sorted(daily_dir.glob("*.md"))
     else:
         daily_paths = []
-    changed = False
+    today_name = f"{current.strftime('%Y-%m-%d')}.md"
+    changed_today = False
+    changed_earlier = False
     for path in daily_paths:
         path_stat = path.lstat()
         if stat.S_ISLNK(path_stat.st_mode) or not stat.S_ISREG(path_stat.st_mode):
             raise ValueError(f"unsafe-daily-source:{path.name}")
         if ingested.get(path.name) != _sha256(path):
-            changed = True
-            break
-    if not changed:
+            if path.name == today_name:
+                changed_today = True
+            else:
+                changed_earlier = True
+                break
+    if not (changed_today or changed_earlier):
+        return False
+    # Off-hours catch-up only compiles days that are done. Today's log is still
+    # being written; compiling it early would ingest a partial day.
+    if not on_schedule and not changed_earlier:
         return False
 
     state_dir.mkdir(parents=True, exist_ok=True)
@@ -507,13 +525,21 @@ def _sweep_stale_hook_inputs(
 
 def _parse_args(argv: Sequence[str] | None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--hook-input", required=True, type=Path)
+    parser.add_argument("--hook-input", type=Path)
     parser.add_argument(
         "--reason",
         choices=("sessionend", "precompact"),
         default="sessionend",
     )
-    return parser.parse_args(argv)
+    parser.add_argument(
+        "--maybe-compile",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    parsed = parser.parse_args(argv)
+    if not parsed.maybe_compile and parsed.hook_input is None:
+        parser.error("--hook-input is required")
+    return parsed
 
 
 def _flush_once(args: argparse.Namespace, event_time: dt.datetime) -> int:
@@ -624,6 +650,15 @@ def main(argv: Sequence[str] | None = None) -> int:
     except SystemExit as exc:
         if exc.code:
             write_health(STATE_DIR, "invalid-arguments")
+        return 0
+
+    if args.maybe_compile:
+        try:
+            maybe_trigger_compile(VAULT_ROOT, _event_now(), catch_up=True)
+        except (OSError, ValueError, json.JSONDecodeError):
+            write_health(STATE_DIR, "compile-catchup-failed")
+        except Exception as exc:  # Hook boundary: never fail a session start.
+            write_health(STATE_DIR, f"unexpected:{exc.__class__.__name__}")
         return 0
 
     managed_input = _managed_hook_input(args.hook_input, STATE_DIR)

--- a/tests/scripts_test.py
+++ b/tests/scripts_test.py
@@ -454,6 +454,49 @@ raise SystemExit(int(os.environ.get("BEYIN_TEST_EXIT", "0")))
             (self.state / "compile-trigger-2026-08-23").exists()
         )
 
+    def test_catch_up_triggers_only_for_earlier_days(self) -> None:
+        today = self.daily / "2026-08-23.md"
+        yesterday = self.daily / "2026-08-22.md"
+        today.write_text("bugun", encoding="utf-8")
+        yesterday.write_text("dun", encoding="utf-8")
+        launches = []
+
+        def fake_popen(*args, **kwargs):
+            launches.append((args, kwargs))
+            return object()
+
+        current = dt.datetime(2026, 8, 23, 10, 0)
+        self.assertTrue(
+            FLUSH.maybe_trigger_compile(
+                self.vault,
+                current,
+                fake_popen,
+                catch_up=True,
+            )
+        )
+        launch_argv = launches[0][0][0]
+        self.assertEqual(
+            launch_argv[-2:],
+            ["--before-date", "2026-08-23"],
+        )
+
+        (self.state / "compile-trigger-2026-08-23").unlink()
+        yesterday_digest = hashlib.sha256(yesterday.read_bytes()).hexdigest()
+        (self.state / "compile-state.json").write_text(
+            json.dumps({"ingested": {yesterday.name: yesterday_digest}}),
+            encoding="utf-8",
+        )
+        launches.clear()
+        self.assertFalse(
+            FLUSH.maybe_trigger_compile(
+                self.vault,
+                current,
+                fake_popen,
+                catch_up=True,
+            )
+        )
+        self.assertEqual(launches, [])
+
     def test_hook_and_compile_temp_files_are_cleaned(self) -> None:
         transcript = self._write_transcript([("user", "temizlik")])
         current_hook = self._write_hook("cleanup-session", transcript, managed=True)
@@ -645,6 +688,31 @@ raise SystemExit(int(os.environ.get("BEYIN_TEST_EXIT", "0")))
             (self.state / "compile-state.json").read_text(encoding="utf-8")
         )
         self.assertEqual(state["last_status"], "fail:no-changes")
+
+    def test_compiler_releases_successful_trigger_claim(self) -> None:
+        (self.daily / "2026-08-20.md").write_text("log", encoding="utf-8")
+        claim = self.state / "compile-trigger-2026-08-23"
+        claim.write_text("", encoding="utf-8")
+        result = self._run_compile("--trigger-claim", str(claim))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertFalse(claim.exists())
+
+    def test_before_date_excludes_partial_current_day(self) -> None:
+        yesterday = self.daily / "2026-08-22.md"
+        today = self.daily / "2026-08-23.md"
+        yesterday.write_text("tam gun", encoding="utf-8")
+        today.write_text("kismi gun", encoding="utf-8")
+        result = self._run_compile("--before-date", "2026-08-23")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        calls = self._stub_calls("sonnet")
+        self.assertEqual(len(calls), 1)
+        self.assertIn(yesterday.name, calls[0]["prompt"])
+        self.assertNotIn(today.name, calls[0]["prompt"])
+        state = json.loads(
+            (self.state / "compile-state.json").read_text(encoding="utf-8")
+        )
+        self.assertIn(yesterday.name, state["ingested"])
+        self.assertNotIn(today.name, state["ingested"])
 
     def test_compile_promotes_allowed_diff_and_hash_skips_unchanged(self) -> None:
         daily_path = self.daily / "2026-08-20.md"


### PR DESCRIPTION
Two defects that keep the evening compile from running. Both are platform independent and both fail silently: nothing errors, the daily log simply never reaches `knowledge/`.

## 1. The trigger claim leaks on the success path

Every failure path in `compile.py` `main()` calls `_release_trigger_claim`, but the success path returns straight out of `_run_locked` without one. A compile that worked therefore leaves its `compile-trigger-<date>` file behind, and the `O_EXCL` create in `maybe_trigger_compile` then refuses every later trigger for the rest of that day.

The system breaks only when it *succeeds*, which is part of why it is easy to miss. The other part: a manual `python3 compile.py` never reproduces it, because without `--trigger-claim` there is no claim to leak.

Fixed by releasing in a `finally`, which covers all paths. The call is idempotent, so the failure paths that already release stay correct.

## 2. `maybe_trigger_compile` has only one call site

It is called from SessionEnd and returns early before 18:00, so a day whose last session closes before 18:00 never reaches the evening pass at all and its log sits uncompiled indefinitely. There is no clock or scheduler behind it — if nobody ends a session after 18:00 that day, nothing runs.

Fixed with a `catch_up` parameter and a `--maybe-compile` entry point called from `session-start.sh`, detached and after the context is emitted so it can neither delay the session nor corrupt the hook's JSON on stdout.

The catch-up pass deliberately compiles **only days that are already over**: if the only changed log is today's it returns, because today's log is still being written and ingesting it early would capture a partial day.

## Verification

Six scenarios covering both call sites:

| scenario | expected | result |
| --- | --- | --- |
| 19:00 SessionEnd, today changed | fire | ✅ |
| 15:30 SessionEnd, today changed | skip (unchanged behaviour) | ✅ |
| 10:00 catch-up, only today changed | skip | ✅ |
| 10:00 catch-up, yesterday uningested | fire | ✅ |
| 10:00 catch-up, nothing changed | skip | ✅ |
| 19:00 catch-up, today changed | fire | ✅ |

The pre-existing SessionEnd behaviour is unchanged.

## Note on how these were found

Both surfaced while running the engine on Windows, where `flush.py` and `compile.py` cannot be imported at all — `fcntl` is POSIX-only. The logic above was exercised through a test-only `fcntl` stub. The import problem itself, and `tests/scripts_test.py` which also does `import fcntl` at line 7 and so cannot run on Windows either, are left for separate changes.
