### PR TITLE
Fix compile.py: stage outside .claude/, which Claude CLI silently protects

### DIFF
--- a/template/.claude/scripts/compile.py
+++ b/template/.claude/scripts/compile.py
@@ -327,8 +327,23 @@ def _prepare_stage(
     daily_path: Path,
 ) -> tuple[Path, dict[str, str | None]]:
     state_dir.mkdir(parents=True, exist_ok=True)
-    stage = Path(tempfile.mkdtemp(prefix="compile-stage-", dir=state_dir))
+    # Staged outside the vault (system tempdir), not under state_dir/.claude/:
+    # Claude CLI auto-protects any path inside a project's .claude/ as
+    # "sensitive" and silently refuses Write/Edit there even under
+    # --permission-mode acceptEdits, which made every real compile run fail
+    # with no-allowed-file-changes.
+    stage = Path(tempfile.mkdtemp(prefix="beyin-compile-stage-"))
     stage.chmod(0o700)
+    try:
+        inside_vault = (
+            os.path.commonpath([stage.resolve(), vault_root.resolve()])
+            == str(vault_root.resolve())
+        )
+    except ValueError:
+        inside_vault = False
+    if inside_vault:
+        shutil.rmtree(stage, ignore_errors=True)
+        raise PolicyError("stage-inside-vault")
     live_baseline: dict[str, str | None] = {}
     try:
         knowledge_source = vault_root / "knowledge"

--- a/tests/scripts_test.py
+++ b/tests/scripts_test.py
@@ -751,8 +751,15 @@ raise SystemExit(int(os.environ.get("BEYIN_TEST_EXIT", "0")))
             ],
         )
         call_cwd = Path(str(call["cwd"]))
-        self.assertEqual(call_cwd.parent.resolve(), self.state.resolve())
-        self.assertTrue(call_cwd.name.startswith("compile-stage-"))
+        # The stage must live outside the vault entirely (and thus outside
+        # .claude/), not under state_dir: Claude CLI auto-protects any path
+        # inside a project's .claude/ as "sensitive" and silently refuses
+        # Write/Edit there even under --permission-mode acceptEdits.
+        self.assertNotEqual(
+            os.path.commonpath([call_cwd.resolve(), self.vault.resolve()]),
+            str(self.vault.resolve()),
+        )
+        self.assertTrue(call_cwd.name.startswith("beyin-compile-stage-"))
         self.assertEqual(call["guard"], "beyin-scripts")
 
     def test_compile_stops_batch_on_first_failure(self) -> None:

--- a/tests/scripts_test.py
+++ b/tests/scripts_test.py
@@ -604,6 +604,29 @@ raise SystemExit(int(os.environ.get("BEYIN_TEST_EXIT", "0")))
         self.assertNotIn(daily_path.name, state["ingested"])
         self.assertEqual(state["last_status"], "fail:no-changes")
 
+    def test_compile_rejects_temp_stage_inside_vault(self) -> None:
+        daily_path = self.daily / "2026-08-20.md"
+        daily_path.write_text("kalıcı günlük", encoding="utf-8")
+        unsafe_temp = self.vault / "tmp"
+        unsafe_temp.mkdir()
+        result = self._run_compile(
+            TMPDIR=str(unsafe_temp),
+            TEMP=str(unsafe_temp),
+            TMP=str(unsafe_temp),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self._stub_calls("sonnet"), [])
+        state = json.loads(
+            (self.state / "compile-state.json").read_text(encoding="utf-8")
+        )
+        self.assertNotIn(daily_path.name, state["ingested"])
+        self.assertEqual(state["last_status"], "fail:policy")
+        health = json.loads(
+            (self.state / "health.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(health["error"], "stage-inside-vault")
+        self.assertEqual(list(unsafe_temp.glob("beyin-compile-stage-*")), [])
+
     def test_staged_deletion_is_rejected_before_promotion(self) -> None:
         daily_path = self.daily / "2026-08-20.md"
         daily_path.write_text("silme denemesi", encoding="utf-8")

--- a/tests/scripts_test.py
+++ b/tests/scripts_test.py
@@ -760,6 +760,7 @@ raise SystemExit(int(os.environ.get("BEYIN_TEST_EXIT", "0")))
             str(self.vault.resolve()),
         )
         self.assertTrue(call_cwd.name.startswith("beyin-compile-stage-"))
+        self.assertFalse(call_cwd.exists())
         self.assertEqual(call["guard"], "beyin-scripts")
 
     def test_compile_stops_batch_on_first_failure(self) -> None:

--- a/tests/scripts_test_windows.py
+++ b/tests/scripts_test_windows.py
@@ -672,6 +672,29 @@ raise SystemExit(int(os.environ.get("BEYIN_TEST_EXIT", "0")))
         self.assertNotIn(daily_path.name, state["ingested"])
         self.assertEqual(state["last_status"], "fail:no-changes")
 
+    def test_compile_rejects_temp_stage_inside_vault(self) -> None:
+        daily_path = self.daily / "2026-08-20.md"
+        daily_path.write_text("kalıcı günlük", encoding="utf-8")
+        unsafe_temp = self.vault / "tmp"
+        unsafe_temp.mkdir()
+        result = self._run_compile(
+            TMPDIR=str(unsafe_temp),
+            TEMP=str(unsafe_temp),
+            TMP=str(unsafe_temp),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(self._stub_calls("sonnet"), [])
+        state = json.loads(
+            (self.state / "compile-state.json").read_text(encoding="utf-8")
+        )
+        self.assertNotIn(daily_path.name, state["ingested"])
+        self.assertEqual(state["last_status"], "fail:policy")
+        health = json.loads(
+            (self.state / "health.json").read_text(encoding="utf-8")
+        )
+        self.assertEqual(health["error"], "stage-inside-vault")
+        self.assertEqual(list(unsafe_temp.glob("beyin-compile-stage-*")), [])
+
     def test_staged_deletion_is_rejected_before_promotion(self) -> None:
         daily_path = self.daily / "2026-08-20.md"
         daily_path.write_text("silme denemesi", encoding="utf-8")

--- a/tests/scripts_test_windows.py
+++ b/tests/scripts_test_windows.py
@@ -823,8 +823,16 @@ raise SystemExit(int(os.environ.get("BEYIN_TEST_EXIT", "0")))
             ],
         )
         call_cwd = Path(str(call["cwd"]))
-        self.assertEqual(call_cwd.parent.resolve(), self.state.resolve())
-        self.assertTrue(call_cwd.name.startswith("compile-stage-"))
+        # The stage must live outside the vault entirely (and thus outside
+        # .claude/), not under state_dir: Claude CLI auto-protects any path
+        # inside a project's .claude/ as "sensitive" and silently refuses
+        # Write/Edit there even under --permission-mode acceptEdits.
+        self.assertNotEqual(
+            os.path.commonpath([call_cwd.resolve(), self.vault.resolve()]),
+            str(self.vault.resolve()),
+        )
+        self.assertTrue(call_cwd.name.startswith("beyin-compile-stage-"))
+        self.assertFalse(call_cwd.exists())
         self.assertEqual(call["guard"], "beyin-scripts")
 
     def test_compile_stops_batch_on_first_failure(self) -> None:


### PR DESCRIPTION
Fixes #5.

## Bug

`_prepare_stage()` created its staging tempdir under `state_dir` (`<vault>/.claude/scripts/.state/`), which is inside `.claude/`. Claude CLI treats any path under a project's `.claude/` as sensitive and silently refuses `Write`/`Edit` there, even with `--permission-mode acceptEdits --allowedTools Read,Write,Edit,Glob,Grep`. The model gets a refusal, gives up gracefully, and exits 0 with no changes; `_validate_manifest_diff()` then correctly (from its own view) raises `NoChangesError`. Every real `compile.py` run failed with `fail:no-changes`, and `knowledge/` never got populated — this isn't environment-specific, every install hits it since it's the staging path choice itself.

Full repro/analysis in #5.

## Fix

Stage in the system tempdir instead of under `state_dir`, with the same inside-vault guard `flush.py` already uses for its own temp dir. `state_dir` keeps being used for the lock file, `compile-state.json`, and `health.json` — only the staging tempdir moves.

## Testing

- Manual repro against a real daily log: `status: ok`, concept + connection files written, index/log updated correctly.
- Full suite: `python3 tests/scripts_test.py` — 24/24 pass. One test (`test_compile_promotes_allowed_diff_and_hash_skips_unchanged`) had asserted the old, buggy cwd location (`state/compile-stage-*`) as expected behavior; updated it to assert the stage is outside the vault entirely and uses the new `beyin-compile-stage-` prefix.

## Scope note

I only touched `main` here. `v2` has the identical `mkdtemp(..., dir=state_dir)` line (same bug), but that branch already has an open NO-GO security gate review (`docs/GATE-REVIEW-SECURITY.md`) — didn't want to touch it inside that review's scope without knowing your intended sequencing. Happy to port this fix there too if useful once that gate is resolved.