### PR TITLE
fix(upgrade): ignore and untrack __pycache__ on MODE B upgrades (#11)

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -122,6 +122,27 @@ assert_no_secret_staged() {
   fi
 }
 
+untrack_ignored_pycache() {
+  # .gitignore now carries __pycache__/ and *.pyc, but an ignore rule never untracks a path that
+  # is already in the index. A vault upgraded before those rules existed keeps its compiled
+  # bytecode tracked: the finalize gate imports the scripts, python rewrites the .pyc files, and
+  # "git add" stages them into the upgrade commit on every single run. Untrack them here, before
+  # the snapshot, and leave every file on disk.
+  #
+  # Deliberately separate from untrack_ignored_secrets: bytecode is not a secret, so this must not
+  # print the "revoke your API key" warning that function ends with.
+  command -v git >/dev/null 2>&1 || return 0
+  [ -d "$V/.git" ] || return 0
+  TRACKED_PYC=$(git -C "$V" ls-files -- '*.pyc' '*/__pycache__/*' 2>/dev/null | sort -u || printf '')
+  [ -n "$TRACKED_PYC" ] || return 0
+  PYC_COUNT=$(printf '%s\n' "$TRACKED_PYC" | grep -c . || printf '0')
+  printf '%s\n' "$TRACKED_PYC" | while IFS= read -r PYC; do
+    [ -n "$PYC" ] || continue
+    git -C "$V" rm --cached -q -- "$PYC" >/dev/null 2>&1 || :
+  done
+  say "izlemeden çıkarıldı (derlenmiş Python, dosyalar diskte duruyor): $PYC_COUNT adet"
+}
+
 record() { printf '%s\n' "$1" >> "$MANIFEST"; }
 
 copy_file() {
@@ -158,6 +179,8 @@ ensure_gitignore() {
 .DS_Store
 .obsidian/workspace*
 .obsidian/cache
+__pycache__/
+*.pyc
 IGN
   say "gitignore: $GI_ADDED satır eklendi"
 }
@@ -318,6 +341,7 @@ if [ "$STAGE" = "apply" ]; then
   step "1/9 .gitignore (anlık görüntüden ÖNCE, sır sahnelenmesin diye)"
   ensure_gitignore
   untrack_ignored_secrets
+  untrack_ignored_pycache
 
   step "2/9 anlık görüntü (doğrulanmış)"
   SNAP_OK=0

--- a/tests/upgrade_transaction_test.sh
+++ b/tests/upgrade_transaction_test.sh
@@ -495,6 +495,42 @@ bash -n "$UPGRADE"
 bash -n "$FIXTURE"
 bash -n "$0"
 
+test_untracks_tracked_pycache() {
+  # A vault upgraded before .gitignore knew about __pycache__ carries compiled bytecode in the
+  # index. Adding the ignore rule alone does not fix that, so the upgrade must also untrack it,
+  # and it must leave the files on disk: python regenerates them, they are not the user's data.
+  local case_dir vault pyc rel still_tracked
+  case_dir=$(new_case)
+  vault="$case_dir/vault"
+  make_v1_vault "$vault" --clean-local
+  prepare_finalizable_vault "$vault"
+
+  rel=".claude/scripts/__pycache__/flush.cpython-312.pyc"
+  pyc="$vault/$rel"
+  mkdir -p "$(dirname "$pyc")"
+  printf 'not real bytecode, only a tracked placeholder\n' > "$pyc"
+  git -C "$vault" add -f -- "$rel" >/dev/null 2>&1 || { diag "fikstür: .pyc eklenemedi"; return 1; }
+  git -C "$vault" -c user.name=fixture -c user.email=fixture@example.invalid \
+    commit -q -m "v1: derlenmis bytecode izleniyor" || { diag "fikstür: commit basarisiz"; return 1; }
+  git -C "$vault" ls-files --error-unmatch -- "$rel" >/dev/null 2>&1 \
+    || { diag "fikstür kurulamadi: .pyc izlenmiyor"; return 1; }
+
+  run_upgrade "$case_dir" "$case_dir/apply.out" --vault "$vault" --stage apply
+  assert_eq 0 "$RUN_STATUS" "apply basarisiz" || { diag "$(cat "$case_dir/apply.out")"; return 1; }
+  run_upgrade "$case_dir" "$case_dir/finalize.out" --vault "$vault" --stage finalize
+  assert_eq 0 "$RUN_STATUS" "finalize basarisiz" || { diag "$(cat "$case_dir/finalize.out")"; return 1; }
+
+  assert_file "$pyc" || { diag ".pyc diskten silinmis olmamali"; return 1; }
+
+  still_tracked=$(git -C "$vault" ls-files -- '*.pyc' '*/__pycache__/*' | tr '\n' ' ')
+  if [ -n "$still_tracked" ]; then
+    diag "yukseltmeden sonra hala izlenen bytecode var: $still_tracked"
+    return 1
+  fi
+  grep -qxF '__pycache__/' "$vault/.gitignore" || { diag ".gitignore __pycache__/ icermiyor"; return 1; }
+  grep -qxF '*.pyc' "$vault/.gitignore" || { diag ".gitignore *.pyc icermiyor"; return 1; }
+}
+
 run_case "--vault olmadan apply kullanım hatası verir ve yazmaz" test_missing_vault
 run_case "göreli --vault kullanım hatasıyla reddedilir" test_relative_vault
 run_case "kök dizin vault olarak reddedilir ve değişmez" test_root_vault
@@ -512,6 +548,7 @@ run_case "git ikilisi yokken harici doğrulanmış yedek dalı gerçekten çalı
 run_case "yeniden adlandırma onayı yoksa apply atomik olarak 10 döndürür" test_rename_confirmation_is_atomic
 run_case "yeniden adlandırma Core.md içeriğini aynen korur" test_rename_preserves_core
 run_case "kullanıcının kendi kancası yükseltmede aynen korunur" test_user_hook_preserved
+run_case "izlenen __pycache__ artıkları izden çıkarılır ama diskte kalır" test_untracks_tracked_pycache
 
 printf '1..%s\n' "$TEST_COUNT"
 [ "$FAIL_COUNT" -eq 0 ]


### PR DESCRIPTION
Fixes #11.

## What changes

1. `ensure_gitignore()` learns `__pycache__/` and `*.pyc`, so its list stops being a subset of `template/.gitignore`.
2. New `untrack_ignored_pycache()`, run in step 1/9 right after `untrack_ignored_secrets()` and before the snapshot. It drops tracked bytecode from the index and **leaves every file on disk**.

Patterns alone would only help new vaults: an ignore rule never untracks a path already in the index — the same reason `untrack_ignored_secrets()` exists.

The new function is deliberately separate rather than an extra loop inside `untrack_ignored_secrets()`. That function ends with a "revoke your key at the provider" warning, which is correct for the paths it guards and would be a false alarm for compiled bytecode.

## Test

`test_untracks_tracked_pycache` starts from a vault that already has a tracked `.pyc`, runs `apply` + `finalize`, and asserts four things: the file still exists on disk, nothing matching `*.pyc` or `*/__pycache__/*` is tracked afterwards, and both patterns are present in `.gitignore`.

I did not want a test that passes for the wrong reason, so I checked that it fails for the right one — two independent mutations, each restored and re-verified by checksum:

| mutation | result |
| --- | --- |
| drop the `untrack_ignored_pycache` call | red — the pre-existing `.pyc` is still tracked |
| drop the two `.gitignore` patterns | red — **four** `.pyc` files are tracked: the ones the finalize gate itself generates by importing the shipped scripts |

The second mutation is the original bug reproduced hermetically.

Full suite on this branch: `upgrade_transaction_test.sh` 18/18, `upgrade_settings_test.sh` 12/12, `hooks_test.sh` 16/16, `scripts_test.py` 27/27.

## Not included

History rewriting. Bytecode already in past commits stays there; that is a separate job and, unlike a leaked credential, it is harmless. This change stops it from growing.
