### PR TITLE
feat: graf bütünlüğü kontrolü (kırık bağlantı + yetim not)

### DIFF
--- a/scripts/upgrade.sh
+++ b/scripts/upgrade.sh
@@ -25,7 +25,7 @@ BEYIN_TARGET_VERSION="2.1.0"
 BEYIN_SCRIPT_VERSION="2.1.0"
 BEYIN_MEMORY_DIR_NAME="🔮 850-Companion"
 BEYIN_HOOK_FILES="lib.sh session-start.sh prompt-counter.sh session-end.sh pre-compact.sh"
-BEYIN_SCRIPT_FILES="flush.py compile.py _portalock.py render_codex_hooks.py"
+BEYIN_SCRIPT_FILES="flush.py compile.py _portalock.py render_codex_hooks.py graf_kontrol.py"
 BEYIN_SKILL_DIRS="beyin-doktor gecmis-import"
 BEYIN_BACKUP_ROOT="${BEYIN_BACKUP_ROOT:-$HOME/.avenoxbeyin-yedek}"
 

--- a/template/.claude/scripts/graf_kontrol.py
+++ b/template/.claude/scripts/graf_kontrol.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Scan the vault graph for broken wikilinks and orphan notes."""
+
+# Bir not ancak ona giden bir kenar varsa bulunur. Yetim not diskte durur ama
+# ajan ona ulasmak icin butun vault'u taramak zorunda kalir: ya token yakar ya
+# bulamayip uydurur. Kirik baglanti ise haritada olmayan bir adresi gosterir.
+# Ikisi de sessiz arizadir, baska hicbir kontrol yakalamaz.
+#
+# Celiski taramasi (ayni olay iki notta farkli tarihte, bir notta "canli"
+# digerinde "beklemede") bu script'te YOK: o model isidir, koda sigmaz.
+#
+# Bagimlilik yok, stdlib yeter. Vault kokunden calistir:
+#   python3 .claude/scripts/graf_kontrol.py            # ozet
+#   python3 .claude/scripts/graf_kontrol.py --tam      # tam liste
+#   python3 .claude/scripts/graf_kontrol.py --selftest # kendi kontrolu
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+# --- AYAR ---------------------------------------------------------------------
+# Taranmayan klasorler.
+ATLA_KLASOR = {".git", ".claude", ".obsidian", "node_modules", "📦 900-Archive"}
+
+# Yetim sayilmayan klasorler: sablonlar (baglanmasi beklenmez), gunluk loglar
+# (kronolojik, birbirine link vermez), knowledge/ (derleyici uretir).
+YETIM_MUAF_KLASOR = {"📋 Templates", "daily", "knowledge"}
+
+# Yetim sayilmayan dosyalar. Ilk satir giris dosyalari.
+# Ikinci satir onemli: bu dosyalara hicbir not link vermez ama session-start
+# kancasi iceriklerini her oturumda enjekte eder. Yani ulasilabilirligin iki
+# yolu var, link ve kanca; kanca ile ulasilani yetim saymak her turda yanlis
+# alarm uretir.
+YETIM_MUAF_DOSYA = {
+    "README", "CLAUDE", "MEMORY", "SETUP", "Dashboard",
+    "Journal", "Kurallar", "Threads", "Last-Session", "Core",
+}
+# ------------------------------------------------------------------------------
+
+# Hedefi ilk ], |, # veya ^ karakterinde keser: [[yol#baslik|takma-ad]] calisir.
+LINK = re.compile(r"\[\[([^\]|#^]+)")
+KIRP = 10
+
+
+def tara(kok: Path):
+    """Return (scanned count, broken links, orphan notes) for the vault at kok."""
+    dosyalar = [
+        p for p in kok.rglob("*.md")
+        if not any(a in p.parts for a in ATLA_KLASOR)
+    ]
+    # Hedef cozumleme: hem dosya adi hem koke gore tam yol (uzantisiz) kabul edilir.
+    hedefler = set()
+    yol_ile = {}
+    ad_ile = {}
+    for p in dosyalar:
+        yol = str(p.relative_to(kok).with_suffix(""))
+        hedefler.add(p.stem)
+        hedefler.add(yol)
+        yol_ile[yol] = p
+        ad_ile.setdefault(p.stem, p)
+
+    kirik = []
+    gelen = {p: 0 for p in dosyalar}
+
+    for p in dosyalar:
+        try:
+            metin = p.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        for ham in LINK.findall(metin):
+            # Tablo icindeki [[yol\|takma-ad]] kacisini ve klasor linklerini ayikla.
+            hedef = ham.rstrip("\\").strip()
+            if not hedef or hedef.endswith("/") or hedef.startswith(("http://", "https://")):
+                continue
+            if hedef not in hedefler:
+                kirik.append((p.relative_to(kok), hedef))
+                continue
+            varis = yol_ile.get(hedef) or ad_ile.get(hedef)
+            if varis is not None and varis != p:
+                gelen[varis] += 1
+
+    yetim = [
+        p.relative_to(kok) for p, n in gelen.items()
+        if n == 0
+        and not any(m in p.parts for m in YETIM_MUAF_KLASOR)
+        and p.stem not in YETIM_MUAF_DOSYA
+    ]
+    return len(dosyalar), kirik, sorted(yetim, key=str)
+
+
+def main() -> None:
+    tam = "--tam" in sys.argv
+    toplam, kirik, yetim = tara(Path("."))
+    print(f"taranan: {toplam} not | kirik baglanti: {len(kirik)} | yetim not: {len(yetim)}")
+
+    if kirik:
+        print("\nKIRIK BAGLANTILAR:")
+        goster = kirik if tam else kirik[:KIRP]
+        for kaynak, hedef in goster:
+            print(f"  {kaynak} -> [[{hedef}]]")
+        if len(kirik) > len(goster):
+            print(f"  ... +{len(kirik) - len(goster)} tane daha (--tam ile hepsi)")
+
+    if yetim:
+        print("\nYETIM NOTLAR (hicbir not buraya baglanmiyor):")
+        if tam:
+            for y in yetim:
+                print(f"  {y}")
+        else:
+            # Duz liste yuzlerce satir olabiliyor; klasor basina sayim okunabilir kalir.
+            sayim = {}
+            for y in yetim:
+                klasor = y.parts[0] if len(y.parts) > 1 else "(kok)"
+                sayim[klasor] = sayim.get(klasor, 0) + 1
+            for klasor, n in sorted(sayim.items(), key=lambda kv: -kv[1]):
+                print(f"  {n:3d}  {klasor}")
+            print("  (--tam ile dosya listesi)")
+
+
+def _selftest() -> None:
+    """Minimal check for vaults installed without the repo test suite."""
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as d:
+        kok = Path(d)
+        (kok / "a.md").write_text("[[b]] ve [[yok-boyle]]", encoding="utf-8")
+        (kok / "b.md").write_text("govde", encoding="utf-8")
+        (kok / "c.md").write_text("kimse bana baglanmiyor", encoding="utf-8")
+        toplam, kirik, yetim = tara(kok)
+        assert toplam == 3, toplam
+        assert [h for _, h in kirik] == ["yok-boyle"], kirik
+        assert [str(y) for y in yetim] == ["a.md", "c.md"], yetim
+    print("selftest: gecti")
+
+
+if __name__ == "__main__":
+    _selftest() if "--selftest" in sys.argv else main()

--- a/template/.claude/skills/beyin-doktor/SKILL.md
+++ b/template/.claude/skills/beyin-doktor/SKILL.md
@@ -211,6 +211,25 @@ Düzeltme: yedeği vault dışına taşı ve `chmod 600` ver; git izliyorsa
 `git rm --cached <dosya>` ile izlemeden çıkar, `.gitignore` kuralını doğrula, ve
 sızmış anahtarı sağlayıcıdan **iptal edip yenile**.
 
+### 16. Grafik bütünlüğü (kırık bağlantı + yetim not)
+
+```bash
+python3 .claude/scripts/graf_kontrol.py
+```
+
+Hafıza düz bir dosya yığını değil **graf**: bir not ancak ona giden bir bağlantı varsa
+bulunur. Yetim not diskte durur ama ajan ona ulaşmak için bütün vault'u taramak zorunda
+kalır, yani ya token yakar ya bulamayıp uydurur. Kırık bağlantı ise haritada var olmayan
+bir adresi gösterir. İkisini de başka hiçbir kontrol yakalamıyor.
+
+🟢 kırık bağlantı 0. 🟡 kırık bağlantı 1–20. 🔴 kırık bağlantı 20 üstü.
+Yetim sayısı tek başına 🔴 değildir: taslak, arşivlik ve tek seferlik notlar doğal olarak
+yetimdir. Asıl bakılacak yer `🔮 850-Companion` — hafıza dosyalarından biri yetim çıkarsa
+süreklilik zinciri kopmuş demektir.
+Düzeltme: `--tam` ile listeyi aç. Kırık bağlantı için ya hedef notu oluştur ya bağlantıyı
+düzelt; hedef bilerek yoksa (belgede örnek olarak geçen `[[wikilink]]` gibi) dokunma.
+Yetim not için ilgili üs nottan veya `Dashboard.md`'den bağlantı ver.
+
 ## Rapor formatı
 
 Tüm kontroller bittikten sonra tek tablo bas:
@@ -234,6 +253,7 @@ Tüm kontroller bittikten sonra tek tablo bas:
 | Kurallar | 🟢 | var, 24 satır |
 | Çift etkin kanca | 🔴 | SessionEnd 2 kez bağlı |
 | Sır yedeği artığı | 🟢 | temiz |
+| Grafik bütünlüğü | 🟡 | 4 kırık bağlantı, 12 yetim not |
 ```
 
 Tablodan sonra sadece 🔴 satırlar için "Düzeltme:" ile başlayan birer satır yaz, komutu da ver.

--- a/tests/scripts_test.py
+++ b/tests/scripts_test.py
@@ -47,6 +47,7 @@ FLUSH = load_module("beyin_flush_test", SOURCE_SCRIPTS / "flush.py")
 CODEX_RENDERER = load_module(
     "beyin_codex_renderer_test", SOURCE_SCRIPTS / "render_codex_hooks.py"
 )
+GRAF = load_module("beyin_graf_test", SOURCE_SCRIPTS / "graf_kontrol.py")
 
 
 class ScriptsTest(unittest.TestCase):
@@ -908,6 +909,54 @@ raise SystemExit(int(os.environ.get("BEYIN_TEST_EXIT", "0")))
         self.assertEqual(compile_result.returncode, 0)
         self.assertEqual(self._stub_calls(), [])
         self.assertFalse((self.state / "health.json").exists())
+
+
+class GrafKontrolTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(prefix="beyin-graf-tests-")
+        self.vault = Path(self.temporary.name)
+        self.addCleanup(self.temporary.cleanup)
+
+    def write(self, rel: str, text: str) -> None:
+        path = self.vault / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8")
+
+    def test_reports_broken_links_and_orphans(self) -> None:
+        self.write("a.md", "[[b]] ve [[yok-boyle]]")
+        self.write("b.md", "govde")
+        self.write("c.md", "kimse bana baglanmiyor")
+        total, broken, orphans = GRAF.tara(self.vault)
+        self.assertEqual(total, 3)
+        self.assertEqual([target for _, target in broken], ["yok-boyle"])
+        self.assertEqual([str(o) for o in orphans], ["a.md", "c.md"])
+
+    def test_resolves_full_paths_headings_and_aliases(self) -> None:
+        # Tablo icindeki [[yol\|takma-ad]] kacisi ve [[not#baslik]] kirik sayilmamali.
+        self.write("🏰 300-Projects/proje.md", "govde")
+        self.write(
+            "hub.md",
+            "[[🏰 300-Projects/proje]] [[proje#baslik]] [[🏰 300-Projects/proje\\|takma]]",
+        )
+        _, broken, orphans = GRAF.tara(self.vault)
+        self.assertEqual(broken, [])
+        self.assertNotIn("🏰 300-Projects/proje.md", [str(o) for o in orphans])
+
+    def test_hook_injected_and_skipped_paths_are_not_orphans(self) -> None:
+        # Kanca ile enjekte edilen hafiza dosyalari ve muaf klasorler yetim sayilmaz.
+        self.write("🔮 850-Companion/Journal.md", "gunluk")
+        self.write("📋 Templates/Note.md", "sablon")
+        self.write("daily/2026-01-01.md", "log")
+        self.write("📦 900-Archive/eski.md", "arsiv")
+        total, broken, orphans = GRAF.tara(self.vault)
+        self.assertEqual(broken, [])
+        self.assertEqual(orphans, [])
+        self.assertEqual(total, 3)  # 900-Archive hic taranmaz
+
+    def test_folder_and_external_targets_are_ignored(self) -> None:
+        self.write("hub.md", "[[🏰 300-Projects/]] [[https://ornek.com]]")
+        _, broken, _ = GRAF.tara(self.vault)
+        self.assertEqual(broken, [])
 
 
 if __name__ == "__main__":

--- a/tests/upgrade_transaction_test.sh
+++ b/tests/upgrade_transaction_test.sh
@@ -307,7 +307,7 @@ test_fresh_shell_chain() {
     cmp -s "$TEST_ROOT/template/.claude/hooks/$hook" "$vault/.claude/hooks/$hook" \
       || { diag "v2 kancası kaynakla aynı değil: $hook"; return 1; }
   done
-  for script in flush.py compile.py _portalock.py render_codex_hooks.py; do
+  for script in flush.py compile.py _portalock.py render_codex_hooks.py graf_kontrol.py; do
     assert_file "$vault/.claude/scripts/$script" || return 1
     cmp -s "$TEST_ROOT/template/.claude/scripts/$script" "$vault/.claude/scripts/$script" \
       || { diag "v2 scripti kaynakla aynı değil: $script"; return 1; }


### PR DESCRIPTION
Hafıza düz bir dosya yığını değil graf: bir not ancak ona giden bir bağlantı varsa bulunur. Yetim not diskte durur ama ajan ona ulaşmak için bütün vault'u taramak zorunda kalır, yani ya token yakar ya bulamayıp uydurur. Kırık bağlantı ise haritada var olmayan bir adresi gösterir. İkisi de sessiz arıza, mevcut 15 kontrolün hiçbiri yakalamıyordu.

Kendi vault'umda ilk taramada 214 notta 33 kırık bağlantı ve 87 yetim not çıktı. İşe yarayan kısım kırık bağlantı tarafı oldu: iki projenin hiç yazılmamış notlara link verdiğini böyle gördüm.

## Ne var

- `template/.claude/scripts/graf_kontrol.py` — wikilink grafiğini kurar, hedefi olmayan bağlantıları ve gelen bağlantısı olmayan notları raporlar. Stdlib dışında bağımlılık yok.
- `beyin-doktor`'a 16. kontrol olarak bağlandı.
- `upgrade.sh` içindeki `BEYIN_SCRIPT_FILES` listesine eklendi. Bu olmadan yükseltme script'i hiçbir vault'a kurmuyordu, dosya repoda durup işe yaramıyordu.
- `tests/scripts_test.py`'a dört test.

## Kurarken çıkan asıl bulgu

Journal, Threads, Kurallar, Last-Session ve Core yetim görünüyor çünkü onlara hiçbir not link vermiyor. Ama `session-start` zaten içeriklerini her oturumda enjekte ediyor. Yani ulaşılabilirliğin iki yolu var, link ve kanca. Kanca ile ulaşılanı yetim saymak her turda yanlış alarm üretiyordu, o yüzden muaf listesi tutmak gerekti. Daha temiz bir yolu varsa memnuniyetle değiştiririm.

## Verdiğim kararlar

Sen "kendin karar ver" dediğin için dördünü de ben seçtim, itiraz edersen değiştiririm:

1. **Kapsam.** Sadece mekanik yarısı var. Çelişki taraması (aynı olay iki notta farklı tarihte, bir notta "canlı" diğerinde "beklemede") bu PR'da yok: kodu olmayan, testi olmayan, model işi bir kontrol. Ayrı konuşulsun istedim.
2. **Yapılandırma.** Muaf listeleri dosyanın başında işaretli bir `AYAR` bloğunda sabit olarak duruyor. Yeni bir yapılandırma mekanizması eklemedim.
3. **Test.** Repo konvansiyonuna uyup `tests/scripts_test.py`'a ekledim. Script'in içindeki `--selftest`'i de bıraktım, çünkü template kullanıcının vault'una `tests/` olmadan kuruluyor; orada tek kontrol yolu o. Fazla bulursan çıkarabilirim.
4. **Eşik.** Yetim sayısını tek başına 🔴 saymadım, taslak ve tek seferlik notlar doğal olarak yetim. Kırık bağlantıyı sinyal saydım. Bu senin ürününe dair bir görüş, eşikler sende farklıysa söyle.

## Test durumu

`python3 -m unittest tests.scripts_test` → 31 test, hepsi geçiyor (27 mevcut + 4 yeni).
`bash tests/upgrade_settings_test.sh` → 12/12 geçiyor.
`bash tests/upgrade_transaction_test.sh` → 16/17. Düşen test 14 (`git ikilisi yokken harici doğrulanmış yedek dalı`) bende **temiz upstream/main'de de düşüyor**, sebebi "sahte PATH hâlâ git görüyor" yani testin kendi kurulumu bu makinede yapılamıyor. Benim değişikliğimle ilgisi yok, ama teyit etmek istersen kendi ortamında bakman iyi olur.

Windows tarafına dokunmadım: `install.ps1` `template/`'i toptan kopyaladığı için script kendiliğinden gidiyor.
